### PR TITLE
fix listen addr to look like :8080

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,5 +125,5 @@ func main() {
 	}()
 
 	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-	log.Fatal(http.ListenAndServe(strconv.Itoa(exporter.Port), nil))
+	log.Fatal(http.ListenAndServe(':' + strconv.Itoa(exporter.Port), nil))
 }


### PR DESCRIPTION
Otherwise we're getting errors like:

```
2024/06/10 14:51:53 listen tcp: address 9111: missing port in address
```

Reference https://pkg.go.dev/net/http#example-ListenAndServe